### PR TITLE
support postgresql reserved word

### DIFF
--- a/lib/DBIx/Inspector/Column/Pg.pm
+++ b/lib/DBIx/Inspector/Column/Pg.pm
@@ -1,0 +1,27 @@
+package DBIx::Inspector::Column::Pg;
+use strict;
+use warnings;
+use utf8;
+use base qw/DBIx::Inspector::Column/;
+
+sub new {
+    my $class = shift;
+    my %args = @_ == 1 ? %{ $_[0] } : @_;
+
+    if ( exists $args{ PK_NAME } ) {
+        # primary_key_info returns pg_column with mistaken value.
+        # I have no idea in case of quotated column name intentionally.
+        $args{COLUMN_NAME} =~ s{^"(.+)"$}{$1};
+    }
+    else {
+        # pg_column contains the unquoted name.
+        # DBD::Pg v1.xx does not support the attribue,
+        # but don't you use such a old module, do you?
+        $args{ COLUMN_NAME } = $args{ pg_column };
+    }
+
+    bless {%args}, $class;
+}
+
+1;
+

--- a/lib/DBIx/Inspector/Table/Pg.pm
+++ b/lib/DBIx/Inspector/Table/Pg.pm
@@ -1,0 +1,14 @@
+package DBIx::Inspector::Table::Pg;
+use strict;
+use warnings;
+use utf8;
+use base qw/DBIx::Inspector::Table/;
+
+# They return unquoted name.
+# DBD::Pg v1.xx does not support these attribues,
+# but don't you use such a old module, do you?
+sub name   { $_[0]->{ pg_table } }
+sub schema { $_[0]->{ pg_schema } }
+
+1;
+

--- a/t/03_pg.t
+++ b/t/03_pg.t
@@ -88,5 +88,28 @@ subtest 'foreign key' => sub {
     }
 };
 
+
+subtest 'system reserved word' => sub {
+    my $dbh = DBI->connect($pgsql->dsn, undef, undef, {Warn => 0, RaiseError => 1}) or die;
+    $dbh->do(q{
+        create table "user" (
+            "user" serial primary key,
+            name varchar(255)
+        );
+    });
+    my $inspector = DBIx::Inspector->new(dbh => $dbh);
+    my @tables = $inspector->tables;
+    ok( grep { $_->name eq 'user' } @tables );
+    my ($user) =  $inspector->table('user');
+    ok $user;
+    is $user->schema, 'public';
+    is $user->type, 'TABLE';
+    is(join(',', sort map { $_->name } $user->columns), 'name,user');
+    is(join(',', sort map { $_->name } $user->primary_key), 'user');
+};
+
+
+
+
 done_testing;
 


### PR DESCRIPTION
DBD::Pg's table_info and column_info  return quoted names if they require (ex. SQL reserved word),
In such a case, DBIx::Inspector::Iterator doesn't work.
This patch supports them.
