### PR TITLE
D::I::Column::Pg and D::I::Table::Pg do not work.

### DIFF
--- a/lib/DBIx/Inspector/Column/Pg.pm
+++ b/lib/DBIx/Inspector/Column/Pg.pm
@@ -17,7 +17,7 @@ sub new {
         # pg_column contains the unquoted name.
         # DBD::Pg v1.xx does not support the attribue,
         # but don't you use such a old module, do you?
-        $args{ COLUMN_NAME } = $args{ pg_column };
+        $args{ COLUMN_NAME } = $args{ PG_COLUMN };
     }
 
     bless {%args}, $class;

--- a/lib/DBIx/Inspector/Table/Pg.pm
+++ b/lib/DBIx/Inspector/Table/Pg.pm
@@ -7,8 +7,8 @@ use base qw/DBIx::Inspector::Table/;
 # They return unquoted name.
 # DBD::Pg v1.xx does not support these attribues,
 # but don't you use such a old module, do you?
-sub name   { $_[0]->{ pg_table } }
-sub schema { $_[0]->{ pg_schema } }
+sub name   { $_[0]->{ PG_TABLE } }
+sub schema { $_[0]->{ PG_SCHEMA } }
 
 1;
 


### PR DESCRIPTION
nihen さんの修正 (b4e9fd1cfc) でカラム名が必ず大文字で返るようになったため、DBIx::Inspector::Column::Pg / DBIx::Inspector::Table::Pg も大文字でアクセスする必要があります。
その部分を修正しましたので merge をお願いします。
