### PR TITLE
PrimaryKey が存在しないテーブルについて

### DIFF
--- a/lib/DBIx/Inspector/Driver/Pg.pm
+++ b/lib/DBIx/Inspector/Driver/Pg.pm
@@ -52,6 +52,9 @@ sub primary_key {
     my ($self, $table) = @_;
 
     my $sth = $self->dbh->primary_key_info( $self->catalog, $self->schema, $table );
+    unless (defined $sth) {
+        return wantarray ? ( ) : DBIx::Inspector::Iterator::Null->new( );
+    }
     my $iter = DBIx::Inspector::Iterator->new(
         callback => sub { DBIx::Inspector::Column::Pg->new(inspector => $self, %{$_[0]}) },
         sth =>$sth,

--- a/t/03_pg.t
+++ b/t/03_pg.t
@@ -24,9 +24,15 @@ subtest 'basic' => sub {
             name varchar(255)
         );
     });
+    $dbh->do(q{
+        create table nopk (
+            nopk_id serial not null,
+            name varchar(255)
+        );
+    });
     my $inspector = DBIx::Inspector->new(dbh => $dbh);
     my @tables = $inspector->tables;
-    is(join(",", sort map { $_->name } @tables), 'post,usr');
+    is(join(",", sort map { $_->name } @tables), 'nopk,post,usr');
     my ($post) = grep { $_->name eq 'post' } @tables;
     isa_ok $post, 'DBIx::Inspector::Table';
     ok $post;
@@ -34,6 +40,8 @@ subtest 'basic' => sub {
     is $post->type, 'TABLE';
     is(join(',', sort map { $_->name } $post->columns), 'body,post_id,user_id');
     is(join(',', sort map { $_->name } $post->primary_key), 'post_id');
+    my ($nopk) = grep { $_->name eq 'nopk' } @tables;
+    isa_ok $nopk->primary_key, 'DBIx::Inspector::Iterator::Null';
 };
 
 subtest 'foreign key' => sub {


### PR DESCRIPTION
PostgreSQL で PrimaryKey が存在しないテーブルに対して $inspector->primary_key($table_name) すると、DBIx::Inspector::Iterator の内部でエラーが発生してしまう (Can't call method "fetchrow_hashref" on an undefined value) ため、そのような場合には DBIx::Inspector::Driver::Pg が DBIx::Inspector::Iterator::Null を返すように修正しました。
