### PR TITLE
DBIx::Inspector::Driver::Pg:: foreign_keys( ) の振る舞いについて

### DIFF
--- a/lib/DBIx/Inspector/Driver/Pg.pm
+++ b/lib/DBIx/Inspector/Driver/Pg.pm
@@ -27,7 +27,7 @@ sub foreign_keys {
     my $sth = $self->dbh->foreign_key_info(@args);
     unless (defined $sth) {
         # DBD::Pg's foreign_key_info returns undef at sometime
-        return DBIx::Inspector::Iterator::Null->new();
+        return wantarray ? ( ) : DBIx::Inspector::Iterator::Null->new( );
     }
     my $iter = DBIx::Inspector::Iterator->new(
         callback => sub { DBIx::Inspector::ForeignKey::Pg->new(inspector => $self, %{$_[0]}) },

--- a/t/03_pg.t
+++ b/t/03_pg.t
@@ -72,18 +72,26 @@ subtest 'foreign key' => sub {
     {
         my $iter = $inspector->table('child')->pk_foreign_keys();
         is $iter->next(), undef;
+        my @fks = $inspector->table('child')->pk_foreign_keys();
+        is scalar @fks, 0;
     }
     {
         my $iter = $inspector->table('parent')->fk_foreign_keys();
         is $iter->next(), undef;
-    }
-    {
-        my $iter = $inspector->table('other')->fk_foreign_keys();
-        is $iter->next(), undef;
+        my @fks = $inspector->table('parent')->fk_foreign_keys();
+        is scalar @fks, 0;
     }
     {
         my $iter = $inspector->table('other')->pk_foreign_keys();
         is $iter->next(), undef;
+        my @fks = $inspector->table('other')->pk_foreign_keys();
+        is scalar @fks, 0;
+    }
+    {
+        my $iter = $inspector->table('other')->fk_foreign_keys();
+        is $iter->next(), undef;
+        my @fks = $inspector->table('other')->fk_foreign_keys();
+        is scalar @fks, 0;
     }
     {
         my $iter = $inspector->table('child')->fk_foreign_keys();


### PR DESCRIPTION
DBIx::Inspector::Driver::Pg:: foreign_keys( ) が外部キーが見つかった場合と見つからなかった場合で、戻り値に対する挙動が違うので一致するように修正してみました。
